### PR TITLE
feat: Add verification logging for orthogonal corrections

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -184,6 +184,7 @@ def run_abliteration(args: argparse.Namespace):
         output_dir=args.output_dir,
         model=model,
         tokenizer=tokenizer,
+        config=model.config,
         abliteration_log=abliteration_log,
         source_model_path=str(model_path)
     )

--- a/core/abliteration.py
+++ b/core/abliteration.py
@@ -189,6 +189,11 @@ def get_ablated_parameters(model: nn.Module, refusal_vector: mx.array, target_mo
             w_float = mx.dequantize(W, scales, biases, module.group_size, module.bits)
             proj_W_on_v = v_proj @ (v_norm_T @ w_float)
             w_ablated_float = w_float - proj_W_on_v
+
+            # Verification check
+            check_norm = mx.linalg.norm(v_norm_T @ w_ablated_float).item()
+            logger.info(f"Orthogonalization check for {key}: norm is {check_norm:.4e}", extra={"extra_info": {"event": "ortho_check", "inputs": {"key": key}, "actual_output": {"norm": check_norm}}})
+
             new_w, new_scales, new_biases = mx.quantize(w_ablated_float, module.group_size, module.bits)
 
             new_flat_params.extend([(key, new_w), (scales_key, new_scales)])
@@ -203,6 +208,11 @@ def get_ablated_parameters(model: nn.Module, refusal_vector: mx.array, target_mo
             proj_W_on_v = v_proj @ (v_norm_T @ W)
             # Subtract the projection to make the new weights orthogonal to the vector
             W_ablated = W - proj_W_on_v
+
+            # Verification check
+            check_norm = mx.linalg.norm(v_norm_T @ W_ablated).item()
+            logger.info(f"Orthogonalization check for {key}: norm is {check_norm:.4e}", extra={"extra_info": {"event": "ortho_check", "inputs": {"key": key}, "actual_output": {"norm": check_norm}}})
+
             new_flat_params.append((key, W_ablated))
             modified_count += 1
 


### PR DESCRIPTION
Adds logging to the `get_ablated_parameters` function to print the norm of the dot product between the refusal vector and the ablated weight matrices. This provides a quantitative check to confirm that the orthogonalization is successful, with the resulting norm being close to zero.

This directly addresses the user's need to confirm that orthogonal corrections are being made.

fix: Ensure model config is saved with ablated model

The `save_ablated_model` function was being called from the CLI without the necessary `model.config` argument. This resulted in the `config.json` file not being saved for the ablated model, which would cause errors or incorrect behavior when trying to load the model later.

The fix passes the `model.config` to the save function, ensuring the ablated model is saved completely and can be loaded correctly.