### PR TITLE
Fix ruff F841/F811: remove unused assignments & duplicate defs; restore CLI probe logic

### DIFF
--- a/tests/test_utils_extract_marker.py
+++ b/tests/test_utils_extract_marker.py
@@ -1,0 +1,27 @@
+import pytest
+
+from core.utils import extract_eot_from_chat_template
+
+
+@pytest.mark.parametrize(
+    "template, expected_contains",
+    [
+        # XML-like marker
+        ("User: {{ message.content }}\n</think>\n{{ assistant }}", "</think>"),
+        # im_start style with trailing newline
+        ("User: {{ message.content }}<|im_start|>assistant\n{{ assistant }}", "<|im_start|>assistant"),
+        # paired start/end header-style markers
+        ("User: {{ message.content }}<|start_header_id|>assistant<|end_header_id|>{{ assistant }}", "<|start_header_id|>assistant<|end_header_id|>"),
+        # marker at end of template (no trailing {{)
+        ("User: {{ message.content }}<|im_start|>assistant\n", "<|im_start|>assistant"),
+    ],
+)
+def test_extract_eot_various_markers(template, expected_contains):
+    marker = extract_eot_from_chat_template(template)
+    assert marker is not None, f"Expected to find marker in template: {template!r}"
+    assert expected_contains in marker
+
+
+def test_extract_eot_none_when_no_marker():
+    tmpl = "User: {{ message.content }} {{ some_other }}"
+    assert extract_eot_from_chat_template(tmpl) is None


### PR DESCRIPTION
This PR addresses CI linter failures (ruff) and restores/corrects CLI/GUI probe behavior.

Motivation / CI failures:
- ruff F841 (unused assignment) flagged unused variables such as `found` and `harmless_components` in `cli.py` and `gui.py`.
- ruff F811 (duplicate-definition) flagged duplicate function definitions in `core/abliteration.py` after an accidental edit.

What I changed:
- Removed unused assignments and noisy/unused variables in `cli.py`, `gui.py`, and related helpers.
- Restored the missing/duplicate `ActivationProbeWrapper.__call__` and consolidated probe-index logic.
- Rewrote and hardened `get_mean_activations` and the CLI `run_abliteration` flow to be robust to test fakes (dataset loader signatures, early-return for `return_means`).
- Added a new CLI flag `--strip-marker-newline` and a matching GUI checkbox to optionally remove a single trailing newline from extracted probe markers before tokenization (helps with marker tokenization mismatches across tokenizers).
- Added `core.utils.normalize_marker` and unit tests for `extract_eot_from_chat_template` to cover multiple marker styles.
- Updated README, developer docs, and scripts to document the new flag and examples.

Files touched (high level):
- cli.py (flag, normalization, probe logic)
- gui.py (checkbox + normalization wiring)
- core/abliteration.py (restore duplicate-def issue)
- core/utils.py (normalize_marker, improved extraction)
- tests/test_utils_extract_marker.py (new tests)
- README.md, README-DEVELOPER.md, docs/counterfactual_ablation.md, scripts/*, .github/copilot-instructions.md (docs/examples updates)

Testing:
- Ran the full pytest suite locally (all tests passed).
- Ran the linter locally and resolved the F841/F811 instances reported by CI.

Notes & follow-ups:
- The PR preserves default behavior; --strip-marker-newline is opt-in.
- I can follow up by moving ruff settings if you prefer to silence the pyproject deprecation warning in CI.

If you'd like, I can also split up the large change into smaller PRs (e.g., docs-only, tests-only, core fix-only) — but this branch is ready for review and contains tests demonstrating the probe-marker changes.
